### PR TITLE
fix deprecation warnings for pytorch 1.6+; streamline amsgrad option …

### DIFF
--- a/pypi_packages/adabelief_pytorch/adabelief_pytorch/AdaBelief.py
+++ b/pypi_packages/adabelief_pytorch/adabelief_pytorch/AdaBelief.py
@@ -140,7 +140,7 @@ class AdaBelief(Optimizer):
                         p.data.mul_(1.0 - group['weight_decay'])
                 else:
                     if group['weight_decay'] != 0:
-                        grad.add_(group['weight_decay'], p.data)
+                        grad.add_(p.data, alpha=group['weight_decay'])
 
                 # Update first and second moment running average
                 exp_avg.mul_(beta1).add_(grad, alpha=1 - beta1)


### PR DESCRIPTION
…handling

This PR adresses the deprecation warnings issued when using Pytorch 1.6, namely in the highlighted addcmul_/addcdiv_/add_ calls which will render the code inoperable in the future. It also simplifies the amsgrad option handling by removing the excess code duplication. It's been tested in numerous real world dataset runs and shows no result diffs with the original Adabelief code! 