### PR TITLE
Update ImageNet default weight decay

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The default value is updated, please check if you specify these arguments or use
 |   Task   |  lr | beta1 | beta2 | epsilon | weight_decay | weight_decouple | rectify     | fixed_decay | amsgrad |
 |:--------:|-----|-------|-------|---------|--------------|-----------------|-------------|---------|---------|
 | Cifar    | 1e-3 | 0.9   | 0.999 | 1e-8    | 5e-4         | False           | False      | False   | False   |
-| ImageNet | 1e-3 |0.9   | 0.999 | 1e-8    | 1e-2         | True            | False       | False   | False   |
+| ImageNet | 1e-3 |0.9   | 0.999 | 1e-8    | 1e-4         | True            | False       | False   | False   |
 | Object detection (PASCAL) | 1e-4 | 0.9   | 0.999 | 1e-8    | 1e-4         | False           | False      | False   | False   |
 | LSTM-1layer| 1e-3| 0.9 | 0.999 | 1e-16   | 1.2e-6        | False           | False      | False   | False   |
 | LSTm 2,3 layer|1e-2| 0.9| 0.999 | 1e-12 |  1.2e-6.       | False           | False      | False   | False   |


### PR DESCRIPTION
Hi, thank you for publishing your work!

I was implementing this optimizer in my [dlib branch](https://github.com/arrufat/dlib/tree/adabelief) and I ran some tests on a dataset very similar to ImageNet. I used the default parameters listed here and I the loss was decreasing _really_ slowly.

Then I noticed there is a discrepancy between the default weight decay in the README (1e-2) and the one in the paper (1e-4), so I used 1e-4 and it worked. Is this a typo?