### PR TITLE
Tf 0.3.0

### DIFF
--- a/pypi_packages/adabelief_tf0.3.0/adabelief_tf1/AdaBelief_tf1_test.py
+++ b/pypi_packages/adabelief_tf0.3.0/adabelief_tf1/AdaBelief_tf1_test.py
@@ -1,0 +1,575 @@
+""" Tests for AdaBelief_tf optimizer."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+
+from tensorflow.python.client import session
+from tensorflow.python.eager import context
+from tensorflow.python.framework import constant_op
+from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import ops
+from tensorflow.python.framework import test_util
+from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import math_ops
+from tensorflow.python.ops import resource_variable_ops
+from tensorflow.python.ops import variables
+from tensorflow.python.platform import test
+from adabelief_tf.AdaBelief_tf import AdaBeliefOptimizer
+
+
+def adabelief_update_numpy(
+    param,
+    g_t,
+    t,
+    m,
+    v,
+    lr=0.001,
+    weight_decay=0.0,
+    rectify=True,
+    beta1=0.9,
+    beta2=0.999,
+    epsilon=1e-14,
+):
+    m_t = beta1 * m + (1 - beta1) * g_t
+    v_t = beta2 * v + (1 - beta2) * (m_t - g_t) * (m_t - g_t) + epsilon
+
+    m_t_hat = m_t / (1 - beta1 ** t)
+    v_t_hat = np.sqrt(v_t / (1 - beta2 ** t))
+
+    if rectify:
+        sma_inf = 2.0 / (1.0 - beta2) - 1.0
+        sma_t = sma_inf - 2.0 * t * (beta2 ** t) / (
+            1.0 - (beta2 ** t)
+        )
+
+        r_t = np.sqrt(
+            (sma_t - 4.0)
+            / (sma_inf - 4.0)
+            * (sma_t - 2.0)
+            / (sma_inf - 2.0)
+            * sma_inf
+            / sma_t
+        )
+        sma_threshold = 5.0
+
+        update = np.where(
+            sma_t >= sma_threshold, r_t * m_t_hat / (v_t_hat + epsilon), m_t_hat
+        )
+
+    else:
+        update = m_t_hat / (v_t_hat + epsilon)
+
+    update += weight_decay * param
+
+    param_t = param - lr * update
+
+    return param_t, m_t, v_t
+
+
+class AdaBeliefOptimizerTest(test.TestCase):
+
+  def doTestSparse(self, use_resource=False):
+    for dtype in [dtypes.half, dtypes.float32, dtypes.float64]:
+      with self.cached_session():
+        # Initialize variables for numpy implementation.
+        m0, v0, m1, v1 = 0.0, 0.0, 0.0, 0.0
+        var0_np = np.array([1.0, 2.0], dtype=dtype.as_numpy_dtype)
+        grads0_np = np.array([0.1, 0.1], dtype=dtype.as_numpy_dtype)
+        var1_np = np.array([3.0, 4.0], dtype=dtype.as_numpy_dtype)
+        grads1_np = np.array([0.01, 0.01], dtype=dtype.as_numpy_dtype)
+
+        if use_resource:
+          var0 = resource_variable_ops.ResourceVariable(var0_np)
+          var1 = resource_variable_ops.ResourceVariable(var1_np)
+        else:
+          var0 = variables.RefVariable(var0_np)
+          var1 = variables.RefVariable(var1_np)
+        grads0_np_indices = np.array([0, 1], dtype=np.int32)
+        grads0 = ops.IndexedSlices(
+            constant_op.constant(grads0_np),
+            constant_op.constant(grads0_np_indices), constant_op.constant([2]))
+        grads1_np_indices = np.array([0, 1], dtype=np.int32)
+        grads1 = ops.IndexedSlices(
+            constant_op.constant(grads1_np),
+            constant_op.constant(grads1_np_indices), constant_op.constant([2]))
+        opt = AdaBeliefOptimizer()
+        update = opt.apply_gradients(zip([grads0, grads1], [var0, var1]))
+        variables.global_variables_initializer().run()
+
+        # Fetch params to validate initial values
+        self.assertAllClose([1.0, 2.0], self.evaluate(var0))
+        self.assertAllClose([3.0, 4.0], self.evaluate(var1))
+
+        beta1_power, beta2_power = opt._get_beta_accumulators()
+
+        # Run 3 steps of AdaBelief
+        for t in range(1, 4):
+          self.assertAllCloseAccordingToType(0.9**t, self.evaluate(beta1_power))
+          self.assertAllCloseAccordingToType(0.999**t,
+                                             self.evaluate(beta2_power))
+          update.run()
+
+          var0_np, m0, v0 = adabelief_update_numpy(var0_np, grads0_np, t, m0, v0)
+          var1_np, m1, v1 = adabelief_update_numpy(var1_np, grads1_np, t, m1, v1)
+
+          # Validate updated params
+          self.assertAllCloseAccordingToType(var0_np, self.evaluate(var0))
+          self.assertAllCloseAccordingToType(var1_np, self.evaluate(var1))
+
+  @test_util.run_deprecated_v1
+  def testSparse(self):
+    self.doTestSparse(use_resource=False)
+
+  @test_util.run_deprecated_v1
+  def testResourceSparse(self):
+    self.doTestSparse(use_resource=True)
+
+  @test_util.run_deprecated_v1
+  def testSparseDevicePlacement(self):
+    for index_dtype in [dtypes.int32, dtypes.int64]:
+      with self.cached_session(force_gpu=test.is_gpu_available()):
+        # If a GPU is available, tests that all optimizer ops can be placed on
+        # it (i.e. they have GPU kernels).
+        var = variables.Variable([[1.0], [2.0]])
+        indices = constant_op.constant([0, 1], dtype=index_dtype)
+        gathered_sum = math_ops.reduce_sum(array_ops.gather(var, indices))
+        optimizer = AdaBeliefOptimizer(3.0)
+        minimize_op = optimizer.minimize(gathered_sum)
+        variables.global_variables_initializer().run()
+        minimize_op.run()
+
+  @test_util.run_deprecated_v1
+  def testSparseRepeatedIndices(self):
+    for dtype in [dtypes.half, dtypes.float32, dtypes.float64]:
+      with self.cached_session():
+        repeated_index_update_var = variables.Variable(
+            [[1.0], [2.0]], dtype=dtype)
+        aggregated_update_var = variables.Variable(
+            [[1.0], [2.0]], dtype=dtype)
+        grad_repeated_index = ops.IndexedSlices(
+            constant_op.constant(
+                [0.1, 0.1], shape=[2, 1], dtype=dtype),
+            constant_op.constant([1, 1]),
+            constant_op.constant([2, 1]))
+        grad_aggregated = ops.IndexedSlices(
+            constant_op.constant(
+                [0.2], shape=[1, 1], dtype=dtype),
+            constant_op.constant([1]),
+            constant_op.constant([2, 1]))
+        repeated_update = AdaBeliefOptimizer().apply_gradients(
+            [(grad_repeated_index, repeated_index_update_var)])
+        aggregated_update = AdaBeliefOptimizer().apply_gradients(
+            [(grad_aggregated, aggregated_update_var)])
+        variables.global_variables_initializer().run()
+        self.assertAllClose(aggregated_update_var.eval(),
+                            self.evaluate(repeated_index_update_var))
+        for _ in range(3):
+          repeated_update.run()
+          aggregated_update.run()
+          self.assertAllClose(aggregated_update_var.eval(),
+                              self.evaluate(repeated_index_update_var))
+
+  def doTestBasic(self, use_resource=False, use_callable_params=False):
+    if context.executing_eagerly() and not use_resource:
+      self.skipTest(
+          "Skipping test with use_resource=False and executing eagerly.")
+    for i, dtype in enumerate([dtypes.half, dtypes.float32, dtypes.float64]):
+      with self.session(graph=ops.Graph()):
+        # Initialize variables for numpy implementation.
+        m0, v0, m1, v1 = 0.0, 0.0, 0.0, 0.0
+        var0_np = np.array([1.0, 2.0], dtype=dtype.as_numpy_dtype)
+        grads0_np = np.array([0.1, 0.1], dtype=dtype.as_numpy_dtype)
+        var1_np = np.array([3.0, 4.0], dtype=dtype.as_numpy_dtype)
+        grads1_np = np.array([0.01, 0.01], dtype=dtype.as_numpy_dtype)
+
+        if use_resource:
+          var0 = resource_variable_ops.ResourceVariable(
+              var0_np, name="var0_%d" % i)
+          var1 = resource_variable_ops.ResourceVariable(
+              var1_np, name="var1_%d" % i)
+        else:
+          var0 = variables.RefVariable(var0_np)
+          var1 = variables.RefVariable(var1_np)
+        grads0 = constant_op.constant(grads0_np)
+        grads1 = constant_op.constant(grads1_np)
+
+        learning_rate = lambda: 0.001
+        beta1 = lambda: 0.9
+        beta2 = lambda: 0.999
+        epsilon = lambda: 1e-8
+        if not use_callable_params:
+          learning_rate = learning_rate()
+          beta1 = beta1()
+          beta2 = beta2()
+          epsilon = epsilon()
+
+        opt = AdaBeliefOptimizer(learning_rate=learning_rate)
+        update = opt.apply_gradients(zip([grads0, grads1], [var0, var1]))
+        opt_variables = opt.variables()
+        beta1_power, beta2_power = opt._get_beta_accumulators()
+        self.assertTrue(beta1_power is not None)
+        self.assertTrue(beta2_power is not None)
+        self.assertIn(beta1_power, opt_variables)
+        self.assertIn(beta2_power, opt_variables)
+        # Ensure that non-slot variables are the same type as the requested
+        # variables.
+        self.assertEqual(
+            use_resource,
+            resource_variable_ops.is_resource_variable(beta1_power))
+        self.assertEqual(
+            use_resource,
+            resource_variable_ops.is_resource_variable(beta2_power))
+
+        if not context.executing_eagerly():
+          with ops.Graph().as_default():
+            # Shouldn't return non-slot variables from other graphs.
+            self.assertEqual(0, len(opt.variables()))
+          self.evaluate(variables.global_variables_initializer())
+          # Fetch params to validate initial values
+          self.assertAllClose([1.0, 2.0], self.evaluate(var0))
+          self.assertAllClose([3.0, 4.0], self.evaluate(var1))
+
+        beta1_power, beta2_power = opt._get_beta_accumulators()
+
+        # Run 3 steps of AdaBelief
+        for t in range(1, 4):
+          if not context.executing_eagerly():
+            self.evaluate(update)
+          elif t > 1:
+            opt.apply_gradients(zip([grads0, grads1], [var0, var1]))
+
+          self.assertAllCloseAccordingToType(0.9**(t + 1),
+                                             self.evaluate(beta1_power))
+          self.assertAllCloseAccordingToType(0.999**(t + 1),
+                                             self.evaluate(beta2_power))
+
+          var0_np, m0, v0 = adabelief_update_numpy(var0_np, grads0_np, t, m0, v0)
+          var1_np, m1, v1 = adabelief_update_numpy(var1_np, grads1_np, t, m1, v1)
+
+          # Validate updated params
+          self.assertAllCloseAccordingToType(var0_np, self.evaluate(var0))
+          self.assertAllCloseAccordingToType(var1_np, self.evaluate(var1))
+          if use_resource:
+            self.assertEqual("var0_%d/AdaBeliefOptimizer:0" % (i,),
+                             opt.get_slot(var=var0, name="m").name)
+
+  def testBasic(self):
+    with self.cached_session():
+      self.doTestBasic(use_resource=False)
+
+  @test_util.run_in_graph_and_eager_modes(reset_test=True)
+  def testResourceBasic(self):
+    self.doTestBasic(use_resource=True)
+
+  def testBasicCallableParams(self):
+    with context.eager_mode():
+      self.doTestBasic(use_resource=True, use_callable_params=True)
+
+  @test_util.run_deprecated_v1
+  def testTensorLearningRate(self):
+    for dtype in [dtypes.half, dtypes.float32, dtypes.float64]:
+      with self.cached_session():
+        # Initialize variables for numpy implementation.
+        m0, v0, m1, v1 = 0.0, 0.0, 0.0, 0.0
+        var0_np = np.array([1.0, 2.0], dtype=dtype.as_numpy_dtype)
+        grads0_np = np.array([0.1, 0.1], dtype=dtype.as_numpy_dtype)
+        var1_np = np.array([3.0, 4.0], dtype=dtype.as_numpy_dtype)
+        grads1_np = np.array([0.01, 0.01], dtype=dtype.as_numpy_dtype)
+
+        var0 = variables.Variable(var0_np)
+        var1 = variables.Variable(var1_np)
+        grads0 = constant_op.constant(grads0_np)
+        grads1 = constant_op.constant(grads1_np)
+        opt = AdaBeliefOptimizer(constant_op.constant(0.001))
+        update = opt.apply_gradients(zip([grads0, grads1], [var0, var1]))
+        variables.global_variables_initializer().run()
+
+        # Fetch params to validate initial values
+        self.assertAllClose([1.0, 2.0], self.evaluate(var0))
+        self.assertAllClose([3.0, 4.0], self.evaluate(var1))
+
+        beta1_power, beta2_power = opt._get_beta_accumulators()
+
+        # Run 3 steps of AdaBelief
+        for t in range(1, 4):
+          self.assertAllCloseAccordingToType(0.9**t, self.evaluate(beta1_power))
+          self.assertAllCloseAccordingToType(0.999**t,
+                                             self.evaluate(beta2_power))
+          update.run()
+
+          var0_np, m0, v0 = adabelief_update_numpy(var0_np, grads0_np, t, m0, v0)
+          var1_np, m1, v1 = adabelief_update_numpy(var1_np, grads1_np, t, m1, v1)
+
+          # Validate updated params
+          self.assertAllCloseAccordingToType(var0_np, self.evaluate(var0))
+          self.assertAllCloseAccordingToType(var1_np, self.evaluate(var1))
+
+  @test_util.run_deprecated_v1
+  def testSharing(self):
+    for dtype in [dtypes.half, dtypes.float32, dtypes.float64]:
+      with self.cached_session():
+        # Initialize variables for numpy implementation.
+        m0, v0, m1, v1 = 0.0, 0.0, 0.0, 0.0
+        var0_np = np.array([1.0, 2.0], dtype=dtype.as_numpy_dtype)
+        grads0_np = np.array([0.1, 0.1], dtype=dtype.as_numpy_dtype)
+        var1_np = np.array([3.0, 4.0], dtype=dtype.as_numpy_dtype)
+        grads1_np = np.array([0.01, 0.01], dtype=dtype.as_numpy_dtype)
+
+        var0 = variables.Variable(var0_np)
+        var1 = variables.Variable(var1_np)
+        grads0 = constant_op.constant(grads0_np)
+        grads1 = constant_op.constant(grads1_np)
+        opt = AdaBeliefOptimizer()
+        update1 = opt.apply_gradients(zip([grads0, grads1], [var0, var1]))
+        update2 = opt.apply_gradients(zip([grads0, grads1], [var0, var1]))
+        variables.global_variables_initializer().run()
+
+        beta1_power, beta2_power = opt._get_beta_accumulators()
+
+        # Fetch params to validate initial values
+        self.assertAllClose([1.0, 2.0], self.evaluate(var0))
+        self.assertAllClose([3.0, 4.0], self.evaluate(var1))
+
+        # Run 3 steps of intertwined AdaBelief1 and AdaBelief2.
+        for t in range(1, 4):
+          self.assertAllCloseAccordingToType(0.9**t, self.evaluate(beta1_power))
+          self.assertAllCloseAccordingToType(0.999**t,
+                                             self.evaluate(beta2_power))
+          if t % 2 == 0:
+            update1.run()
+          else:
+            update2.run()
+
+          var0_np, m0, v0 = adabelief_update_numpy(var0_np, grads0_np, t, m0, v0)
+          var1_np, m1, v1 = adabelief_update_numpy(var1_np, grads1_np, t, m1, v1)
+
+          # Validate updated params
+          self.assertAllCloseAccordingToType(var0_np, self.evaluate(var0))
+          self.assertAllCloseAccordingToType(var1_np, self.evaluate(var1))
+
+  def testTwoSessions(self):
+    optimizer = AdaBeliefOptimizer()
+
+    with context.eager_mode():
+      var0 = variables.Variable(np.array([1.0, 2.0]), name="v0")
+      grads0 = constant_op.constant(np.array([0.1, 0.1]))
+      optimizer.apply_gradients([(grads0, var0)])
+
+    g = ops.Graph()
+    with g.as_default():
+      with session.Session():
+        var0 = variables.Variable(np.array([1.0, 2.0]), name="v0")
+        grads0 = constant_op.constant(np.array([0.1, 0.1]))
+        optimizer.apply_gradients([(grads0, var0)])
+
+    gg = ops.Graph()
+    with gg.as_default():
+      with session.Session():
+        var0 = variables.Variable(np.array([1.0, 2.0]), name="v0")
+        grads0 = constant_op.constant(np.array([0.1, 0.1]))
+
+        # If the optimizer saves any state not keyed by graph the following line
+        # fails.
+        optimizer.apply_gradients([(grads0, var0)])
+
+  def testSlotsUniqueEager(self):
+    with context.eager_mode():
+      v1 = resource_variable_ops.ResourceVariable(1.)
+      v2 = resource_variable_ops.ResourceVariable(1.)
+      opt = AdaBeliefOptimizer(1.)
+      opt.minimize(lambda: v1 + v2)
+      # There should be three non-slot variables, and two unique slot variables
+      # for v1 and v2 respectively.
+      self.assertEqual(7, len({id(v) for v in opt.variables()}))
+  
+  def doTestRectify(self, use_resource=False, use_callable_params=False):
+    if context.executing_eagerly() and not use_resource:
+      self.skipTest(
+          "Skipping test with use_resource=False and executing eagerly.")
+    for i, dtype in enumerate([dtypes.half, dtypes.float32, dtypes.float64]):
+      with self.session(graph=ops.Graph()):
+        # Initialize variables for numpy implementation.
+        m0, v0, m1, v1 = 0.0, 0.0, 0.0, 0.0
+        var0_np = np.array([1.0, 2.0], dtype=dtype.as_numpy_dtype)
+        grads0_np = np.array([0.1, 0.1], dtype=dtype.as_numpy_dtype)
+        var1_np = np.array([3.0, 4.0], dtype=dtype.as_numpy_dtype)
+        grads1_np = np.array([0.01, 0.01], dtype=dtype.as_numpy_dtype)
+
+        if use_resource:
+          var0 = resource_variable_ops.ResourceVariable(
+              var0_np, name="var0_%d" % i)
+          var1 = resource_variable_ops.ResourceVariable(
+              var1_np, name="var1_%d" % i)
+        else:
+          var0 = variables.RefVariable(var0_np)
+          var1 = variables.RefVariable(var1_np)
+        grads0 = constant_op.constant(grads0_np)
+        grads1 = constant_op.constant(grads1_np)
+
+        learning_rate = lambda: 0.001
+        beta1 = lambda: 0.9
+        beta2 = lambda: 0.999
+        epsilon = lambda: 1e-8
+        if not use_callable_params:
+          learning_rate = learning_rate()
+          beta1 = beta1()
+          beta2 = beta2()
+          epsilon = epsilon()
+
+        opt = AdaBeliefOptimizer(learning_rate=learning_rate, rectify=False)
+        update = opt.apply_gradients(zip([grads0, grads1], [var0, var1]))
+        opt_variables = opt.variables()
+        beta1_power, beta2_power = opt._get_beta_accumulators()
+        self.assertTrue(beta1_power is not None)
+        self.assertTrue(beta2_power is not None)
+        self.assertIn(beta1_power, opt_variables)
+        self.assertIn(beta2_power, opt_variables)
+        # Ensure that non-slot variables are the same type as the requested
+        # variables.
+        self.assertEqual(
+            use_resource,
+            resource_variable_ops.is_resource_variable(beta1_power))
+        self.assertEqual(
+            use_resource,
+            resource_variable_ops.is_resource_variable(beta2_power))
+
+        if not context.executing_eagerly():
+          with ops.Graph().as_default():
+            # Shouldn't return non-slot variables from other graphs.
+            self.assertEqual(0, len(opt.variables()))
+          self.evaluate(variables.global_variables_initializer())
+          # Fetch params to validate initial values
+          self.assertAllClose([1.0, 2.0], self.evaluate(var0))
+          self.assertAllClose([3.0, 4.0], self.evaluate(var1))
+
+        beta1_power, beta2_power = opt._get_beta_accumulators()
+
+        # Run 3 steps of AdaBelief
+        for t in range(1, 4):
+          if not context.executing_eagerly():
+            self.evaluate(update)
+          elif t > 1:
+            opt.apply_gradients(zip([grads0, grads1], [var0, var1]))
+
+          self.assertAllCloseAccordingToType(0.9**(t + 1),
+                                             self.evaluate(beta1_power))
+          self.assertAllCloseAccordingToType(0.999**(t + 1),
+                                             self.evaluate(beta2_power))
+
+          var0_np, m0, v0 = adabelief_update_numpy(var0_np, grads0_np, t, m0, v0, rectify=False)
+          var1_np, m1, v1 = adabelief_update_numpy(var1_np, grads1_np, t, m1, v1, rectify=False)
+
+          # Validate updated params
+          self.assertAllCloseAccordingToType(var0_np, self.evaluate(var0))
+          self.assertAllCloseAccordingToType(var1_np, self.evaluate(var1))
+          if use_resource:
+            self.assertEqual("var0_%d/AdaBeliefOptimizer:0" % (i,),
+                             opt.get_slot(var=var0, name="m").name)
+
+  def doTestWD(self, use_resource=False, use_callable_params=False):
+    if context.executing_eagerly() and not use_resource:
+      self.skipTest(
+          "Skipping test with use_resource=False and executing eagerly.")
+    for i, dtype in enumerate([dtypes.half, dtypes.float32, dtypes.float64]):
+      with self.session(graph=ops.Graph()):
+        # Initialize variables for numpy implementation.
+        m0, v0, m1, v1 = 0.0, 0.0, 0.0, 0.0
+        var0_np = np.array([1.0, 2.0], dtype=dtype.as_numpy_dtype)
+        grads0_np = np.array([0.1, 0.1], dtype=dtype.as_numpy_dtype)
+        var1_np = np.array([3.0, 4.0], dtype=dtype.as_numpy_dtype)
+        grads1_np = np.array([0.01, 0.01], dtype=dtype.as_numpy_dtype)
+
+        if use_resource:
+          var0 = resource_variable_ops.ResourceVariable(
+              var0_np, name="var0_%d" % i)
+          var1 = resource_variable_ops.ResourceVariable(
+              var1_np, name="var1_%d" % i)
+        else:
+          var0 = variables.RefVariable(var0_np)
+          var1 = variables.RefVariable(var1_np)
+        grads0 = constant_op.constant(grads0_np)
+        grads1 = constant_op.constant(grads1_np)
+
+        learning_rate = lambda: 0.001
+        beta1 = lambda: 0.9
+        beta2 = lambda: 0.999
+        epsilon = lambda: 1e-8
+        if not use_callable_params:
+          learning_rate = learning_rate()
+          beta1 = beta1()
+          beta2 = beta2()
+          epsilon = epsilon()
+
+        opt = AdaBeliefOptimizer(learning_rate=learning_rate, weight_decay=0.01)
+        update = opt.apply_gradients(zip([grads0, grads1], [var0, var1]))
+        opt_variables = opt.variables()
+        beta1_power, beta2_power = opt._get_beta_accumulators()
+        self.assertTrue(beta1_power is not None)
+        self.assertTrue(beta2_power is not None)
+        self.assertIn(beta1_power, opt_variables)
+        self.assertIn(beta2_power, opt_variables)
+        # Ensure that non-slot variables are the same type as the requested
+        # variables.
+        self.assertEqual(
+            use_resource,
+            resource_variable_ops.is_resource_variable(beta1_power))
+        self.assertEqual(
+            use_resource,
+            resource_variable_ops.is_resource_variable(beta2_power))
+
+        if not context.executing_eagerly():
+          with ops.Graph().as_default():
+            # Shouldn't return non-slot variables from other graphs.
+            self.assertEqual(0, len(opt.variables()))
+          self.evaluate(variables.global_variables_initializer())
+          # Fetch params to validate initial values
+          self.assertAllClose([1.0, 2.0], self.evaluate(var0))
+          self.assertAllClose([3.0, 4.0], self.evaluate(var1))
+
+        beta1_power, beta2_power = opt._get_beta_accumulators()
+
+        # Run 3 steps of AdaBelief
+        for t in range(1, 4):
+          if not context.executing_eagerly():
+            self.evaluate(update)
+          elif t > 1:
+            opt.apply_gradients(zip([grads0, grads1], [var0, var1]))
+
+          self.assertAllCloseAccordingToType(0.9**(t + 1),
+                                             self.evaluate(beta1_power))
+          self.assertAllCloseAccordingToType(0.999**(t + 1),
+                                             self.evaluate(beta2_power))
+
+          var0_np, m0, v0 = adabelief_update_numpy(var0_np, grads0_np, t, m0, v0, weight_decay=0.01)
+          var1_np, m1, v1 = adabelief_update_numpy(var1_np, grads1_np, t, m1, v1, weight_decay=0.01)
+
+          # Validate updated params
+          self.assertAllCloseAccordingToType(var0_np, self.evaluate(var0))
+          self.assertAllCloseAccordingToType(var1_np, self.evaluate(var1))
+          if use_resource:
+            self.assertEqual("var0_%d/AdaBeliefOptimizer:0" % (i,),
+                             opt.get_slot(var=var0, name="m").name)
+
+  def testRectify(self):
+    with self.cached_session():
+      self.doTestRectify(use_resource=False)
+
+  @test_util.run_in_graph_and_eager_modes(reset_test=True)
+  def testResourceRectify(self):
+    self.doTestRectify(use_resource=True)
+
+  def testWD(self):
+    with self.cached_session():
+      self.doTestWD(use_resource=False)
+
+  @test_util.run_in_graph_and_eager_modes(reset_test=True)
+  def testResourceWD(self):
+    self.doTestWD(use_resource=True)
+
+
+if __name__ == "__main__":
+  test.main()
+  

--- a/pypi_packages/adabelief_tf0.3.0/adabelief_tf1/LICENSE.txt
+++ b/pypi_packages/adabelief_tf0.3.0/adabelief_tf1/LICENSE.txt
@@ -1,0 +1,19 @@
+Copyright (c) 2018 The Python Packaging Authority
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pypi_packages/adabelief_tf0.3.0/adabelief_tf1/README.md
+++ b/pypi_packages/adabelief_tf0.3.0/adabelief_tf1/README.md
@@ -1,0 +1,1 @@
+Tensorflow implementation of Adabelief Optimizer. For details, please see https://juntang-zhuang.github.io/adabelief/

--- a/pypi_packages/adabelief_tf0.3.0/adabelief_tf1/adabelief_tf/AdaBelief_tf.py
+++ b/pypi_packages/adabelief_tf0.3.0/adabelief_tf1/adabelief_tf/AdaBelief_tf.py
@@ -1,0 +1,376 @@
+""" AdaBelief for TensorFlow 1.x."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import tensorflow as tf
+
+from tensorflow.python.eager import context
+from tensorflow.python.framework import ops
+from tensorflow.python.ops import resource_variable_ops
+
+
+class AdaBeliefOptimizer(tf.train.Optimizer):
+    """
+    It implements the AdaBeliefOptimizer proposed by
+    Juntang Zhuang et al. in [AdaBelief Optimizer: Adapting stepsizes by the belief
+    in observed gradients](https://arxiv.org/abs/2010.07468).
+    Contributor(s):
+        Jerry Yu [cryu854] <cryu854@gmail.com>
+
+    Inherits from: tf.train.Optimizer.
+    Example of usage:
+    ```python
+    from adabelief_tf import AdaBeliefOptimizer
+    opt = AdaBeliefOptimizer(learning_rate=1e-3, epsilon=1e-14, rectify=False)
+    ```
+    """
+
+    def __init__(
+        self,
+        learning_rate=0.001,
+        beta_1=0.9,
+        beta_2=0.999,
+        epsilon=1e-14,
+        weight_decay=0.0,
+        rectify=True,
+        amsgrad=False,
+        sma_threshold=5.0,
+        total_steps=0,
+        warmup_proportion=0.1,
+        min_lr=0.0,
+        name="AdaBeliefOptimizer",
+        use_locking=False,
+        print_change_log = True,
+        **kwargs):
+        r"""Construct a new AdaBelief optimizer.
+        Args:
+            learning_rate: A `Tensor` or a floating point value, or a schedule
+                that is a `tf.keras.optimizers.schedules.LearningRateSchedule`.
+                The learning rate.
+            beta_1: A float value or a constant float tensor.
+                The exponential decay rate for the 1st moment estimates.
+            beta_2: A float value or a constant float tensor.
+                The exponential decay rate for the 2nd moment estimates.
+            epsilon: A small constant for numerical stability.
+            weight_decay: A `Tensor` or a floating point value, or a schedule
+                that is a `tf.keras.optimizers.schedules.LearningRateSchedule`.
+                Weight decay for each parameter.
+            rectify: boolean. Whether to enable rectification as in RectifiedAdam
+            amsgrad: boolean. Whether to apply AMSGrad variant of this
+                algorithm from the paper "On the Convergence of Adam and
+                beyond".
+            sma_threshold. A float value.
+                The threshold for simple mean average.
+            total_steps: An integer. Total number of training steps.
+                Enable warmup by setting a positive value.
+            warmup_proportion: A floating point value.
+                The proportion of increasing steps.
+            min_lr: A floating point value. Minimum learning rate after warmup.
+            name: Optional name for the operations created when applying
+                gradients. Defaults to "AdaBeliefOptimizer".
+            **kwargs: keyword arguments. Allowed to be {`lr`, `decay`}. `decay` 
+                is included for backward compatibility to allow time inverse
+                decay of learning rate. `lr` is included for backward
+                compatibility, recommended to use `learning_rate` instead.
+        """
+        super(AdaBeliefOptimizer, self).__init__(use_locking, name)
+        self._lr = learning_rate
+        self._beta1 = beta_1
+        self._beta2 = beta_2
+        self._epsilon = epsilon
+        self.amsgrad = amsgrad
+        self.rectify = rectify
+
+        decay = kwargs.pop("decay", 0.0)
+        if decay < 0.:
+            raise ValueError("decay cannot be less than 0: {}".format(decay))
+        self._initial_decay = decay
+        self._decay = self._initial_decay
+        self._weight_decay = weight_decay
+        self._sma_threshold = sma_threshold
+        self._total_steps = int(total_steps)
+        self._warmup_proportion = warmup_proportion
+        self._min_lr = min_lr
+        self._has_weight_decay = weight_decay != 0.0
+        self._initial_total_steps = total_steps
+
+        # Tensor versions of the constructor arguments, created in _prepare().
+        self._lr_t = None
+        self._beta1_t = None
+        self._beta2_t = None
+        self._epsilon_t = None
+        self._decay_t = None
+        self._weight_decay_t = None
+        self._total_steps_t = None
+        self._warmup_proportion_t = None
+        self._min_lr_t = None
+        self._sma_threshold_t = None
+
+    def _get_beta_accumulators(self):
+        with ops.init_scope():
+            if context.executing_eagerly():
+                graph = None
+            else:
+                graph = ops.get_default_graph()
+            return (self._get_non_slot_variable("beta1_power", graph=graph),
+                    self._get_non_slot_variable("beta2_power", graph=graph))
+          
+    def _get_step(self):
+        with ops.init_scope():
+            if context.executing_eagerly():
+                graph = None
+            else:
+                graph = ops.get_default_graph()
+            return self._get_non_slot_variable("step", graph=graph)
+
+    def _create_slots(self, var_list):
+        # Create the step, beta1 and beta2 accumulators on the same device as the first variable.
+        first_var = min(var_list, key=lambda x: x.name)
+        self._create_non_slot_variable(
+            initial_value=self._beta1, name="beta1_power", colocate_with=first_var)
+        self._create_non_slot_variable(
+            initial_value=self._beta2, name="beta2_power", colocate_with=first_var)
+        self._create_non_slot_variable(
+            initial_value=1, name="step", colocate_with=first_var)
+
+        # Create slots.
+        for v in var_list:
+            self._zeros_slot(v, "m", self._name)
+            self._zeros_slot(v, "v", self._name)
+            if self.amsgrad:
+                self._zeros_slot(v, "vhat", self._name)
+
+    def _prepare(self):
+        lr = self._call_if_callable(self._lr)
+        beta1 = self._call_if_callable(self._beta1)
+        beta2 = self._call_if_callable(self._beta2)
+        epsilon = self._call_if_callable(self._epsilon)
+        decay = self._call_if_callable(self._decay)
+        weight_decay = self._call_if_callable(self._weight_decay)
+        total_steps = self._call_if_callable(self._total_steps)
+        warmup_proportion = self._call_if_callable(self._warmup_proportion)
+        min_lr = self._call_if_callable(self._min_lr)
+        sma_threshold = self._call_if_callable(self._sma_threshold)
+
+        self._lr_t = ops.convert_to_tensor(lr, name="learning_rate")
+        self._beta1_t = ops.convert_to_tensor(beta1, name="beta1")
+        self._beta2_t = ops.convert_to_tensor(beta2, name="beta2")
+        self._epsilon_t = ops.convert_to_tensor(epsilon, name="epsilon")
+        self._decay_t = ops.convert_to_tensor(decay, name="decay")
+        self._weight_decay_t = ops.convert_to_tensor(weight_decay, name="weight_decay")
+        self._total_steps_t = ops.convert_to_tensor(total_steps, name="total_steps")
+        self._warmup_proportion_t = ops.convert_to_tensor(warmup_proportion, name="warmup_proportion")
+        self._min_lr_t = ops.convert_to_tensor(min_lr, name="min_lr")
+        self._sma_threshold_t = ops.convert_to_tensor(sma_threshold, name="sma_threshold")
+
+    def _decayed_lr(self, var_dtype):
+        """Get decayed learning rate as a Tensor with dtype=var_dtype."""
+        lr_t = tf.cast(self._lr_t, var_dtype)
+        if self._initial_decay > 0.:
+            local_step = tf.cast(self._get_step(), var_dtype)
+            decay_t = tf.cast(self._decay_t, var_dtype)
+            lr_t = lr_t / (1. + decay_t * local_step)
+        return lr_t
+
+    def _apply_dense(self, grad, var):
+        return self._resource_apply_dense(grad, var)
+
+    def _resource_apply_dense(self, grad, var):
+        beta_1_power, beta_2_power = self._get_beta_accumulators()
+        beta_1_power = tf.cast(beta_1_power, var.dtype.base_dtype)
+        beta_2_power = tf.cast(beta_2_power, var.dtype.base_dtype)
+        local_step = tf.cast(self._get_step(), var.dtype.base_dtype)
+        lr_t = self._decayed_lr(var.dtype.base_dtype)
+        wd_t = tf.cast(self._weight_decay_t, var.dtype.base_dtype)
+        beta_1_t = tf.cast(self._beta1_t, var.dtype.base_dtype)
+        beta_2_t = tf.cast(self._beta2_t, var.dtype.base_dtype)
+        epsilon_t = tf.cast(self._epsilon_t, var.dtype.base_dtype)
+
+        # warmup
+        if self._initial_total_steps > 0:
+            total_steps = tf.cast(self._total_steps_t, var.dtype.base_dtype)
+            warmup_steps = total_steps * tf.cast(self._warmup_proportion_t, var.dtype.base_dtype)
+            min_lr = tf.cast(self._min_lr_t, var.dtype.base_dtype)
+            decay_steps = tf.maximum(total_steps - warmup_steps, 1)
+            decay_rate = (min_lr - lr_t) / decay_steps
+            lr_t = tf.cond(
+                local_step <= warmup_steps,
+                lambda: lr_t * (local_step / warmup_steps),
+                lambda: lr_t + decay_rate * tf.minimum(local_step - warmup_steps, decay_steps)
+            )
+
+        # m_t = beta1 * m + (1 - beta1) * g_t
+        m = self.get_slot(var, "m")
+        m_t = tf.assign(
+            m, beta_1_t * m + (1.0 - beta_1_t) * grad, use_locking=self._use_locking
+        )
+        m_corr_t = m_t / (1.0 - beta_1_power)
+
+        # v_t = beta2 * v + (1 - beta2) * (g_t - m_t) * (g_t - m_t)
+        v = self.get_slot(var, "v")
+        v_t = tf.assign(
+            v, beta_2_t * v + (1.0 - beta_2_t) * tf.square(grad - m_t) + epsilon_t,
+            use_locking=self._use_locking,
+        )
+
+        # amsgrad
+        if self.amsgrad:
+            vhat = self.get_slot(var, "vhat")
+            vhat_t = tf.assign(vhat, tf.maximum(vhat, v_t), use_locking=self._use_locking)
+            v_corr_t = tf.sqrt(vhat_t / (1.0 - beta_2_power))
+        else:
+            vhat_t = None
+            v_corr_t = tf.sqrt(v_t / (1.0 - beta_2_power))
+
+
+        # rectify
+        if self.rectify:
+            sma_inf = 2.0 / (1.0 - beta_2_t) - 1.0
+            sma_t = sma_inf - 2.0 * local_step * beta_2_power / (1.0 - beta_2_power)
+            r_t = tf.sqrt(
+                (sma_t - 4.0)
+                / (sma_inf - 4.0)
+                * (sma_t - 2.0)
+                / (sma_inf - 2.0)
+                * sma_inf
+                / sma_t
+            )
+            sma_threshold = tf.cast(self._sma_threshold_t, var.dtype.base_dtype)
+            var_t = tf.cond(
+                sma_t >= sma_threshold,
+                lambda: r_t * m_corr_t / (v_corr_t + epsilon_t),
+                lambda: m_corr_t
+            )
+        else:
+            var_t = m_corr_t / (v_corr_t + epsilon_t)
+
+        # weight_decay
+        if self._has_weight_decay:
+            var_t += wd_t * var
+
+        # update
+        var_update = tf.assign_sub(var, lr_t * var_t, use_locking=self._use_locking)
+ 
+        updates = [var_update, m_t, v_t]
+        if self.amsgrad:
+            updates.append(vhat_t)
+        return tf.group(*updates)
+
+    def _apply_sparse_shared(self, grad, var, indices, scatter_add):
+        beta_1_power, beta_2_power = self._get_beta_accumulators()
+        beta_1_power = tf.cast(beta_1_power, var.dtype.base_dtype)
+        beta_2_power = tf.cast(beta_2_power, var.dtype.base_dtype)
+        local_step = tf.cast(self._get_step(), var.dtype.base_dtype)
+        lr_t = self._decayed_lr(var.dtype.base_dtype)
+        wd_t = tf.cast(self._weight_decay_t, var.dtype.base_dtype)
+        beta_1_t = tf.cast(self._beta1_t, var.dtype.base_dtype)
+        beta_2_t = tf.cast(self._beta2_t, var.dtype.base_dtype)
+        epsilon_t = tf.cast(self._epsilon_t, var.dtype.base_dtype)
+
+        # warmup
+        if self._initial_total_steps > 0:
+            total_steps = tf.cast(self._total_steps_t, var.dtype.base_dtype)
+            warmup_steps = total_steps * tf.cast(self._warmup_proportion_t, var.dtype.base_dtype)
+            min_lr = tf.cast(self._min_lr_t, var.dtype.base_dtype)
+            decay_steps = tf.maximum(total_steps - warmup_steps, 1)
+            decay_rate = (min_lr - lr_t) / decay_steps
+            lr_t = tf.cond(
+                local_step <= warmup_steps,
+                lambda: lr_t * (local_step / warmup_steps),
+                lambda: lr_t + decay_rate * tf.minimum(local_step - warmup_steps, decay_steps)
+            )
+
+        # m_t = beta1 * m + (1 - beta1) * g_t
+        m = self.get_slot(var, "m")
+        m_scaled_g_values = (1.0 - beta_1_t) * grad
+        m_t = tf.assign(m, beta_1_t * m, use_locking=self._use_locking)
+        with ops.control_dependencies([m_t]):
+            m_t = scatter_add(m, indices, m_scaled_g_values)
+        m_corr_t = m_t / (1.0 - beta_1_power)
+
+        # v_t = beta2 * v + (1 - beta2) * (g_t - m_t) * (g_t - m_t)
+        v = self.get_slot(var, "v")
+        m_t_indices = tf.gather(m_t, indices)
+        v_scaled_g_values = (1.0 - beta_2_t) * tf.square(grad - m_t_indices)
+        v_t = tf.assign(v, v * beta_2_t, use_locking=self._use_locking)
+        with ops.control_dependencies([v_t]):
+            v_t = scatter_add(v, indices, v_scaled_g_values + epsilon_t)
+
+        # amsgrad
+        if self.amsgrad:
+            vhat = self.get_slot(var, "vhat")
+            vhat_t = tf.assign(vhat, tf.maximum(vhat, v_t), use_locking=self._use_locking)
+            v_corr_t = tf.sqrt(vhat_t / (1.0 - beta_2_power))
+        else:
+            vhat_t = None
+            v_corr_t = tf.sqrt(v_t / (1.0 - beta_2_power))
+
+        # rectify
+        if self.rectify:
+            sma_inf = 2.0 / (1.0 - beta_2_t) - 1.0
+            sma_t = sma_inf - 2.0 * local_step * beta_2_power / (1.0 - beta_2_power)
+            r_t = tf.sqrt(
+                (sma_t - 4.0)
+                / (sma_inf - 4.0)
+                * (sma_t - 2.0)
+                / (sma_inf - 2.0)
+                * sma_inf
+                / sma_t
+            )
+            sma_threshold = tf.cast(self._sma_threshold_t, var.dtype.base_dtype)
+            var_t = tf.cond(
+                sma_t >= sma_threshold,
+                lambda: r_t * m_corr_t / (v_corr_t + epsilon_t),
+                lambda: m_corr_t
+            )
+        else:
+            var_t = m_corr_t / (v_corr_t + epsilon_t)
+
+        # weight_decay
+        if self._has_weight_decay:
+            var_t += wd_t * var
+
+        # update
+        var_update = tf.assign_sub(var, lr_t * var_t, use_locking=self._use_locking)
+ 
+        updates = [var_update, m_t, v_t]
+        if self.amsgrad:
+            updates.append(vhat_t)
+        return tf.group(*updates)
+
+    def _apply_sparse(self, grad, var):
+        return self._apply_sparse_shared(
+            grad.values,
+            var,
+            grad.indices,
+            lambda x, i, v: tf.scatter_add(  # pylint: disable=g-long-lambda
+                x,
+                i,
+                v,
+                use_locking=self._use_locking))
+
+    def _resource_scatter_add(self, x, i, v):
+        with ops.control_dependencies(
+            [resource_variable_ops.resource_scatter_add(x.handle, i, v)]):
+            return x.value()
+
+    def _resource_apply_sparse(self, grad, var, indices):
+        return self._apply_sparse_shared(grad, var, indices,
+                                         self._resource_scatter_add)
+
+    def _finish(self, update_ops, name_scope):
+        # Update the power accumulators.
+        with ops.control_dependencies(update_ops):
+            beta1_power, beta2_power = self._get_beta_accumulators()
+            step = self._get_step()
+            with ops.colocate_with(step):
+                update_beta1 = beta1_power.assign(
+                                beta1_power * self._beta1_t, use_locking=self._use_locking)
+                update_beta2 = beta2_power.assign(
+                                beta2_power * self._beta2_t, use_locking=self._use_locking)
+                update_step = step.assign(
+                                step + 1, use_locking=self._use_locking)
+        return tf.group(
+            *update_ops + [update_beta1, update_beta2, update_step], name=name_scope)

--- a/pypi_packages/adabelief_tf0.3.0/adabelief_tf1/adabelief_tf/__init__.py
+++ b/pypi_packages/adabelief_tf0.3.0/adabelief_tf1/adabelief_tf/__init__.py
@@ -1,0 +1,2 @@
+from .AdaBelief_tf import AdaBeliefOptimizer
+__version__='0.3.0'

--- a/pypi_packages/adabelief_tf0.3.0/adabelief_tf1/setup.py
+++ b/pypi_packages/adabelief_tf0.3.0/adabelief_tf1/setup.py
@@ -1,0 +1,27 @@
+import setuptools
+
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
+setuptools.setup(     # Should be modified
+    name="adabelief_tf", 
+    version="0.3.0",
+    author="Juntang Zhuang",
+    author_email="j.zhuang@yale.edu",
+    description="Tensorflow implementation of AdaBelief Optimizer",
+    long_description="Tensorflow implementation of AdaBelief Optimizer",
+    long_description_content_type="text/markdown",
+    url="https://juntang-zhuang.github.io/adabelief/",
+    packages=setuptools.find_packages(),
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+    ],
+    install_requires=[
+          'tensorflow>=2.0.0',
+          'colorama>=0.4.0',
+          'tabulate>=0.7',
+      ],
+    python_requires='>=3.6',
+)

--- a/pypi_packages/adabelief_tf0.3.0/adabelief_tf2/AdaBelief_tf2_test.py
+++ b/pypi_packages/adabelief_tf0.3.0/adabelief_tf2/AdaBelief_tf2_test.py
@@ -1,0 +1,616 @@
+""" Tests for AdaBelief_tf optimizer."""
+
+import os
+import sys
+import pytest
+import numpy as np
+import tensorflow as tf
+
+from pathlib import Path
+from adabelief_tf.AdaBelief_tf import AdaBeliefOptimizer
+
+
+def is_gpu_available():
+    return len(tf.config.list_physical_devices("GPU")) >= 1
+
+# Some configuration before starting the tests.
+
+# we only need one core per worker.
+# This avoids context switching for speed, but it also prevents TensorFlow to go
+# crazy on systems with many cores (kokoro has 30+ cores).
+tf.config.threading.set_intra_op_parallelism_threads(1)
+tf.config.threading.set_inter_op_parallelism_threads(1)
+
+
+if is_gpu_available():
+    # We use only the first gpu at the moment. That's enough for most use cases.
+    # split the first gpu into chunks of 100MB per virtual device.
+    # It's the user's job to limit the amount of pytest workers depending
+    # on the available memory.
+    # In practice, each process takes a bit more memory.
+    # There must be some kind of overhead but it's not very big (~200MB more)
+    # Each worker has two virtual devices.
+    # When running on gpu, only the first device is used. The other one is used
+    # in distributed strategies.
+    first_gpu = tf.config.list_physical_devices("GPU")[0]
+    virtual_gpus = [
+        tf.config.LogicalDeviceConfiguration(memory_limit=100) for _ in range(2)
+    ]
+
+    tf.config.set_logical_device_configuration(first_gpu, virtual_gpus)
+
+
+def assert_allclose_according_to_type(
+    a,
+    b,
+    rtol=1e-6,
+    atol=1e-6,
+    float_rtol=1e-6,
+    float_atol=1e-6,
+    half_rtol=1e-3,
+    half_atol=1e-3,
+    bfloat16_rtol=1e-2,
+    bfloat16_atol=1e-2):
+    """
+    Similar to tf.test.TestCase.assertAllCloseAccordingToType()
+    but this doesn't need a subclassing to run.
+    """
+    a = np.array(a)
+    b = np.array(b)
+    # types with lower tol are put later to overwrite previous ones.
+    if (
+        a.dtype == np.float32
+        or b.dtype == np.float32
+        or a.dtype == np.complex64
+        or b.dtype == np.complex64
+    ):
+        rtol = max(rtol, float_rtol)
+        atol = max(atol, float_atol)
+    if a.dtype == np.float16 or b.dtype == np.float16:
+        rtol = max(rtol, half_rtol)
+        atol = max(atol, half_atol)
+    if a.dtype == tf.bfloat16.as_numpy_dtype or b.dtype == tf.bfloat16.as_numpy_dtype:
+        rtol = max(rtol, bfloat16_rtol)
+        atol = max(atol, bfloat16_atol)
+
+    np.testing.assert_allclose(a, b, rtol=rtol, atol=atol)
+
+
+def finalizer():
+    tf.config.run_functions_eagerly(False)
+
+
+@pytest.fixture(scope="function", params=["eager_mode", "tf_function"])
+def maybe_run_functions_eagerly(request):
+    if request.param == "eager_mode":
+        tf.config.run_functions_eagerly(True)
+    elif request.param == "tf_function":
+        tf.config.run_functions_eagerly(False)
+
+    request.addfinalizer(finalizer)
+
+
+def _dtypes_to_test(use_gpu):
+    # Based on issue #347 (https://github.com/tensorflow/addons/issues/347)
+    # tf.half is not registered for 'ResourceScatterUpdate' OpKernel for 'GPU'.
+    # So we have to remove tf.half when testing with gpu.
+    if use_gpu:
+        return [tf.float32, tf.float64]
+    else:
+        return [tf.half, tf.float32, tf.float64]
+
+
+def adabelief_update_numpy(
+    param,
+    g_t,
+    t,
+    m,
+    v,
+    lr=0.001,
+    weight_decay=0.0,
+    rectify=True,
+    beta1=0.9,
+    beta2=0.999,
+    epsilon=1e-14,
+):
+    m_t = beta1 * m + (1 - beta1) * g_t
+    v_t = beta2 * v + (1 - beta2) * (m_t - g_t) * (m_t - g_t) + epsilon
+
+    m_t_hat = m_t / (1 - beta1 ** (t + 1))
+    v_t_hat = np.sqrt(v_t / (1 - beta2 ** (t + 1)))
+
+    if rectify:
+        sma_inf = 2.0 / (1.0 - beta2) - 1.0
+        sma_t = sma_inf - 2.0 * (t + 1) * (beta2 ** (t + 1)) / (
+            1.0 - (beta2 ** (t + 1))
+        )
+        r_t = np.sqrt(
+            (sma_t - 4.0)
+            / (sma_inf - 4.0)
+            * (sma_t - 2.0)
+            / (sma_inf - 2.0)
+            * sma_inf
+            / sma_t
+        )
+        sma_threshold = 5.0
+
+        update = np.where(
+            sma_t >= sma_threshold, r_t * m_t_hat / (v_t_hat + epsilon), m_t_hat
+        )
+
+    else:
+        update = m_t_hat / (v_t_hat + epsilon)
+
+    update += weight_decay * param
+
+    param_t = param - lr * update
+
+    return param_t, m_t, v_t
+
+
+def get_beta_accumulators(opt, dtype):
+    local_step = tf.cast(opt.iterations + 1, dtype)
+    beta_1_t = tf.cast(opt._get_hyper("beta_1"), dtype)
+    beta_1_power = tf.math.pow(beta_1_t, local_step)
+    beta_2_t = tf.cast(opt._get_hyper("beta_2"), dtype)
+    beta_2_power = tf.math.pow(beta_2_t, local_step)
+    return (beta_1_power, beta_2_power)
+
+
+@pytest.mark.usefixtures("maybe_run_functions_eagerly")
+def test_sparse():
+    for dtype in _dtypes_to_test(use_gpu=is_gpu_available()):
+        # Initialize tf for numpy implementation.
+        m0, v0, m1, v1 = 0.0, 0.0, 0.0, 0.0
+        var0_np = np.array([1.0, 1.0, 2.0], dtype=dtype.as_numpy_dtype)
+        grads0_np = np.array([0.1, 0.0, 0.1], dtype=dtype.as_numpy_dtype)
+        var1_np = np.array([3.0, 3.0, 4.0], dtype=dtype.as_numpy_dtype)
+        grads1_np = np.array([0.01, 0.0, 0.01], dtype=dtype.as_numpy_dtype)
+
+        var0 = tf.Variable(var0_np)
+        var1 = tf.Variable(var1_np)
+        grads0_np_indices = np.array([0, 2], dtype=np.int32)
+        grads0 = tf.IndexedSlices(
+            tf.constant(grads0_np[grads0_np_indices]),
+            tf.constant(grads0_np_indices),
+            tf.constant([3]),
+        )
+        grads1_np_indices = np.array([0, 2], dtype=np.int32)
+        grads1 = tf.IndexedSlices(
+            tf.constant(grads1_np[grads1_np_indices]),
+            tf.constant(grads1_np_indices),
+            tf.constant([3]),
+        )
+
+        epsilon = 1e-7
+        optimizer = AdaBeliefOptimizer(epsilon=epsilon)
+
+        # Fetch params to validate initial values
+        np.testing.assert_allclose(np.asanyarray([1.0, 1.0, 2.0]), var0.numpy())
+        np.testing.assert_allclose(np.asanyarray([3.0, 3.0, 4.0]), var1.numpy())
+
+        # Run 3 steps of AdaBelief
+        for t in range(3):
+            beta_1_power, beta_2_power = get_beta_accumulators(optimizer, dtype)
+            assert_allclose_according_to_type(0.9 ** (t + 1), beta_1_power)
+            assert_allclose_according_to_type(0.999 ** (t + 1), beta_2_power)
+
+            optimizer.apply_gradients(zip([grads0, grads1], [var0, var1]))
+            var0_np, m0, v0 = adabelief_update_numpy(var0_np, grads0_np, t, m0, v0, epsilon=epsilon)
+            var1_np, m1, v1 = adabelief_update_numpy(var1_np, grads1_np, t, m1, v1, epsilon=epsilon)
+            # Validate updated params
+            assert_allclose_according_to_type(
+                var0_np, var0.numpy(), atol=2e-4
+            )
+            assert_allclose_according_to_type(
+                var1_np, var1.numpy(), atol=2e-4
+            )
+
+
+@pytest.mark.usefixtures("maybe_run_functions_eagerly")
+def test_basic_with_learning_rate_decay():
+    for i, dtype in enumerate(_dtypes_to_test(use_gpu=is_gpu_available())):
+        # Initialize variables for numpy implementation.
+        m0, v0, m1, v1 = 0.0, 0.0, 0.0, 0.0
+        var0_np = np.array([1.0, 2.0], dtype=dtype.as_numpy_dtype)
+        grads0_np = np.array([0.1, 0.1], dtype=dtype.as_numpy_dtype)
+        var1_np = np.array([3.0, 4.0], dtype=dtype.as_numpy_dtype)
+        grads1_np = np.array([0.01, 0.01], dtype=dtype.as_numpy_dtype)
+
+        var0 = tf.Variable(var0_np, name="var0_%d" % i)
+        var1 = tf.Variable(var1_np, name="var1_%d" % i)
+        grads0 = tf.constant(grads0_np)
+        grads1 = tf.constant(grads1_np)
+
+        learning_rate = 0.001
+        beta_1 = 0.9
+        beta_2 = 0.999
+        epsilon = 1e-14
+        decay = 0.5
+        weight_decay = 0.01
+
+        opt = AdaBeliefOptimizer(
+            learning_rate=learning_rate,
+            beta_1=beta_1,
+            beta_2=beta_2,
+            epsilon=epsilon,
+            weight_decay=weight_decay,
+            decay=decay,
+        )
+
+        # Run 3 steps of AdaBelief
+        for t in range(3):
+            opt.apply_gradients(zip([grads0, grads1], [var0, var1]))
+
+            lr_np = learning_rate / (1 + decay * t)
+
+            var0_np, m0, v0 = adabelief_update_numpy(
+                var0_np, grads0_np, t, m0, v0, lr=lr_np, weight_decay=weight_decay
+            )
+            var1_np, m1, v1 = adabelief_update_numpy(
+                var1_np, grads1_np, t, m1, v1, lr=lr_np, weight_decay=weight_decay
+            )
+
+            # Validate updated params
+            assert_allclose_according_to_type(
+                var0_np, var0.numpy(), atol=2e-4
+            )
+            assert_allclose_according_to_type(
+                var1_np, var1.numpy(), atol=2e-4
+            )
+
+
+@pytest.mark.usefixtures("maybe_run_functions_eagerly")
+def test_basic_with_learning_rate_inverse_time_decay():
+    for i, dtype in enumerate(_dtypes_to_test(use_gpu=is_gpu_available())):
+        # Initialize variables for numpy implementation.
+        m0, v0, m1, v1 = 0.0, 0.0, 0.0, 0.0
+        var0_np = np.array([1.0, 2.0], dtype=dtype.as_numpy_dtype)
+        grads0_np = np.array([0.1, 0.1], dtype=dtype.as_numpy_dtype)
+        var1_np = np.array([3.0, 4.0], dtype=dtype.as_numpy_dtype)
+        grads1_np = np.array([0.01, 0.01], dtype=dtype.as_numpy_dtype)
+
+        var0 = tf.Variable(var0_np, name="var0_%d" % i)
+        var1 = tf.Variable(var1_np, name="var1_%d" % i)
+        grads0 = tf.constant(grads0_np)
+        grads1 = tf.constant(grads1_np)
+
+        learning_rate = 0.001
+        decay = 0.5
+        lr_schedule = tf.keras.optimizers.schedules.InverseTimeDecay(
+            learning_rate, decay_steps=1.0, decay_rate=decay
+        )
+        beta_1 = 0.9
+        beta_2 = 0.999
+        epsilon = 1e-14
+
+        opt = AdaBeliefOptimizer(
+            learning_rate=lr_schedule, beta_1=beta_1, beta_2=beta_2, epsilon=epsilon
+        )
+
+        # Run 3 steps of AdaBelief
+        for t in range(3):
+            opt.apply_gradients(zip([grads0, grads1], [var0, var1]))
+
+            lr_np = learning_rate / (1 + decay * t)
+
+            var0_np, m0, v0 = adabelief_update_numpy(
+                var0_np, grads0_np, t, m0, v0, lr=lr_np
+            )
+            var1_np, m1, v1 = adabelief_update_numpy(
+                var1_np, grads1_np, t, m1, v1, lr=lr_np
+            )
+
+            # Validate updated params
+            assert_allclose_according_to_type(
+                var0_np, var0.numpy(), atol=2e-4
+            )
+            assert_allclose_according_to_type(
+                var1_np, var1.numpy(), atol=2e-4
+            )
+
+
+@pytest.mark.usefixtures("maybe_run_functions_eagerly")
+def test_tensor_learning_rate():
+    for dtype in _dtypes_to_test(use_gpu=is_gpu_available()):
+        # Initialize variables for numpy implementation.
+        m0, v0, m1, v1 = 0.0, 0.0, 0.0, 0.0
+        var0_np = np.array([1.0, 2.0], dtype=dtype.as_numpy_dtype)
+        grads0_np = np.array([0.1, 0.1], dtype=dtype.as_numpy_dtype)
+        var1_np = np.array([3.0, 4.0], dtype=dtype.as_numpy_dtype)
+        grads1_np = np.array([0.01, 0.01], dtype=dtype.as_numpy_dtype)
+
+        var0 = tf.Variable(var0_np)
+        var1 = tf.Variable(var1_np)
+        grads0 = tf.constant(grads0_np)
+        grads1 = tf.constant(grads1_np)
+        opt = AdaBeliefOptimizer(lr=tf.constant(0.001))
+
+        # Fetch params to validate initial values
+        np.testing.assert_allclose(np.asanyarray([1.0, 2.0]), var0.numpy())
+        np.testing.assert_allclose(np.asanyarray([3.0, 4.0]), var1.numpy())
+
+        # Run 3 steps of AdaBelief
+        for t in range(3):
+            beta_1_power, beta_2_power = get_beta_accumulators(opt, dtype)
+            assert_allclose_according_to_type(0.9 ** (t + 1), beta_1_power)
+            assert_allclose_according_to_type(0.999 ** (t + 1), beta_2_power)
+            opt.apply_gradients(zip([grads0, grads1], [var0, var1]))
+
+            var0_np, m0, v0 = adabelief_update_numpy(var0_np, grads0_np, t, m0, v0)
+            var1_np, m1, v1 = adabelief_update_numpy(var1_np, grads1_np, t, m1, v1)
+
+            # Validate updated params
+            assert_allclose_according_to_type(
+                var0_np, var0.numpy(), atol=2e-4
+            )
+            assert_allclose_according_to_type(
+                var1_np, var1.numpy(), atol=2e-4
+            )
+
+
+@pytest.mark.usefixtures("maybe_run_functions_eagerly")
+def test_sharing():
+    for dtype in _dtypes_to_test(use_gpu=is_gpu_available()):
+        # Initialize variables for numpy implementation.
+        m0, v0, m1, v1 = 0.0, 0.0, 0.0, 0.0
+        var0_np = np.array([1.0, 2.0], dtype=dtype.as_numpy_dtype)
+        grads0_np = np.array([0.1, 0.1], dtype=dtype.as_numpy_dtype)
+        var1_np = np.array([3.0, 4.0], dtype=dtype.as_numpy_dtype)
+        grads1_np = np.array([0.01, 0.01], dtype=dtype.as_numpy_dtype)
+
+        var0 = tf.Variable(var0_np)
+        var1 = tf.Variable(var1_np)
+        grads0 = tf.constant(grads0_np)
+        grads1 = tf.constant(grads1_np)
+        opt = AdaBeliefOptimizer()
+
+        # Fetch params to validate initial values
+        np.testing.assert_allclose(np.asanyarray([1.0, 2.0]), var0.numpy())
+        np.testing.assert_allclose(np.asanyarray([3.0, 4.0]), var1.numpy())
+
+        # Run 3 steps of AdaBelief
+        for t in range(3):
+            beta_1_power, beta_2_power = get_beta_accumulators(opt, dtype)
+            assert_allclose_according_to_type(0.9 ** (t + 1), beta_1_power)
+            assert_allclose_according_to_type(0.999 ** (t + 1), beta_2_power)
+
+            opt.apply_gradients(zip([grads0, grads1], [var0, var1]))
+
+            var0_np, m0, v0 = adabelief_update_numpy(var0_np, grads0_np, t, m0, v0)
+            var1_np, m1, v1 = adabelief_update_numpy(var1_np, grads1_np, t, m1, v1)
+
+            # Validate updated params
+            assert_allclose_according_to_type(var0_np, var0.numpy())
+            assert_allclose_according_to_type(var1_np, var1.numpy())
+
+
+def test_minimize_mean_square_loss_with_weight_decay():
+    w = tf.Variable([0.1, -0.2, -0.1])
+    x = tf.constant([0.4, 0.2, -0.5])
+
+    def loss():
+        return tf.reduce_mean(tf.square(x - w))
+
+    opt = AdaBeliefOptimizer(0.02, weight_decay=0.01)
+
+    # Run 200 steps
+    for _ in range(200):
+        opt.minimize(loss, [w])
+    # Validate updated params
+    np.testing.assert_allclose(
+        w.numpy(), np.asanyarray([0.4, 0.2, -0.5]), rtol=1e-2, atol=1e-2
+    )
+
+
+@pytest.mark.usefixtures("maybe_run_functions_eagerly")
+def test_resource():
+    for i, dtype in enumerate(_dtypes_to_test(use_gpu=is_gpu_available())):
+        # Initialize variables for numpy implementation.
+        m0, v0, m1, v1 = 0.0, 0.0, 0.0, 0.0
+        var0_np = np.array([1.0, 2.0], dtype=dtype.as_numpy_dtype)
+        grads0_np = np.array([0.1, 0.1], dtype=dtype.as_numpy_dtype)
+        var1_np = np.array([3.0, 4.0], dtype=dtype.as_numpy_dtype)
+        grads1_np = np.array([0.01, 0.01], dtype=dtype.as_numpy_dtype)
+
+        var0 = tf.Variable(var0_np, name="var0_%d" % i)
+        var1 = tf.Variable(var1_np, name="var1_%d" % i)
+        grads0 = tf.constant(grads0_np)
+        grads1 = tf.constant(grads1_np)
+
+        def learning_rate():
+            return 0.001
+
+        opt = AdaBeliefOptimizer(learning_rate=learning_rate)
+
+        # Run 3 steps of AdaBelief
+        for t in range(3):
+            beta_1_power, beta_2_power = get_beta_accumulators(opt, dtype)
+            assert_allclose_according_to_type(0.9 ** (t + 1), beta_1_power)
+            assert_allclose_according_to_type(0.999 ** (t + 1), beta_2_power)
+
+            opt.apply_gradients(zip([grads0, grads1], [var0, var1]))
+
+            var0_np, m0, v0 = adabelief_update_numpy(var0_np, grads0_np, t, m0, v0)
+            var1_np, m1, v1 = adabelief_update_numpy(var1_np, grads1_np, t, m1, v1)
+
+            # Validate updated params
+            assert_allclose_according_to_type(var0_np, var0.numpy())
+            assert_allclose_according_to_type(var1_np, var1.numpy())
+
+
+def run_dense_sample(iterations, expected, optimizer):
+    var_0 = tf.Variable([1.0, 2.0], dtype=tf.dtypes.float32)
+    var_1 = tf.Variable([3.0, 4.0], dtype=tf.dtypes.float32)
+
+    grad_0 = tf.constant([0.1, 0.2], dtype=tf.dtypes.float32)
+    grad_1 = tf.constant([0.03, 0.04], dtype=tf.dtypes.float32)
+
+    grads_and_vars = list(zip([grad_0, grad_1], [var_0, var_1]))
+
+    for _ in range(iterations):
+        optimizer.apply_gradients(grads_and_vars)
+    np.testing.assert_allclose(var_0.read_value(), expected[0], atol=2e-4)
+    np.testing.assert_allclose(var_1.read_value(), expected[1], atol=2e-4)
+
+
+def run_sparse_sample(iterations, expected, optimizer):
+    var_0 = tf.Variable([1.0, 2.0])
+    var_1 = tf.Variable([3.0, 4.0])
+
+    grad_0 = tf.IndexedSlices(tf.constant([0.1]), tf.constant([0]), tf.constant([2]))
+    grad_1 = tf.IndexedSlices(tf.constant([0.04]), tf.constant([1]), tf.constant([2]))
+
+    grads_and_vars = list(zip([grad_0, grad_1], [var_0, var_1]))
+
+    for _ in range(iterations):
+        optimizer.apply_gradients(grads_and_vars)
+    np.testing.assert_allclose(var_0.read_value(), expected[0], atol=2e-4)
+    np.testing.assert_allclose(var_1.read_value(), expected[1], atol=2e-4)
+
+
+@pytest.mark.usefixtures("maybe_run_functions_eagerly")
+def test_dense_sample():
+    run_dense_sample(
+        iterations=100,
+        expected=[[0.9475605, 1.9471607], [2.94784, 3.9478]],
+        optimizer=AdaBeliefOptimizer(lr=1e-3),
+    )
+
+
+@pytest.mark.usefixtures("maybe_run_functions_eagerly")
+def test_sparse_sample():
+    run_sparse_sample(
+        iterations=200,
+        expected=[[0.78374314, 2.0], [3.0, 3.7839816]],
+        optimizer=AdaBeliefOptimizer(lr=1e-3),
+    )
+
+
+@pytest.mark.usefixtures("maybe_run_functions_eagerly")
+def test_dense_sample_with_amsgrad():
+    run_dense_sample(
+        iterations=100,
+        expected=[[0.9485513, 1.9481515], [2.9488308, 3.9487908]],
+        optimizer=AdaBeliefOptimizer(lr=1e-3, amsgrad=True),
+    )
+
+
+@pytest.mark.usefixtures("maybe_run_functions_eagerly")
+def test_sparse_sample_with_amsgrad():
+    run_sparse_sample(
+        iterations=200,
+        expected=[[0.7947248, 2.0], [3.0, 3.7949643]],
+        optimizer=AdaBeliefOptimizer(lr=1e-3, amsgrad=True),
+    )
+
+
+@pytest.mark.usefixtures("maybe_run_functions_eagerly")
+def test_dense_sample_with_weight_decay():
+    run_dense_sample(
+        iterations=100,
+        expected=[[0.94657826, 1.9451787], [2.9448593, 3.9438188]],
+        optimizer=AdaBeliefOptimizer(lr=1e-3, weight_decay=0.01),
+    )
+
+
+@pytest.mark.usefixtures("maybe_run_functions_eagerly")
+def test_sparse_sample_with_weight_decay():
+    run_sparse_sample(
+        iterations=200,
+        expected=[[0.7818859, 2.0], [3.0, 3.7761304]],
+        optimizer=AdaBeliefOptimizer(lr=1e-3, weight_decay=0.01),
+    )
+
+
+@pytest.mark.usefixtures("maybe_run_functions_eagerly")
+def test_dense_sample_with_warmup():
+    run_dense_sample(
+        iterations=100,
+        expected=[[0.9811546, 1.9810544], [2.981224, 3.981214]],
+        optimizer=AdaBeliefOptimizer(
+            lr=1e-3, total_steps=100, warmup_proportion=0.1, min_lr=1e-5
+        ),
+    )
+
+
+@pytest.mark.usefixtures("maybe_run_functions_eagerly")
+def test_sparse_sample_with_warmup():
+    run_sparse_sample(
+        iterations=200,
+        expected=[[0.9211433, 2.0], [3.0, 3.9211729]],
+        optimizer=AdaBeliefOptimizer(
+            lr=1e-3, total_steps=200, warmup_proportion=0.1, min_lr=1e-5
+        ),
+    )
+
+
+@pytest.mark.usefixtures("maybe_run_functions_eagerly")
+def test_dense_sample_without_rectify():
+    run_dense_sample(
+        iterations=100,
+        expected=[[0.6672395, 1.6672392], [2.667238, 3.6672378]],
+        optimizer=AdaBeliefOptimizer(lr=1e-3, rectify=False),
+    )
+
+
+@pytest.mark.usefixtures("maybe_run_functions_eagerly")
+def test_sparse_sample_without_rectify():
+    run_sparse_sample(
+        iterations=200,
+        expected=[[0.0538935, 2.0], [3.0, 3.0538921]],
+        optimizer=AdaBeliefOptimizer(lr=1e-3, rectify=False),
+    )
+
+
+def test_get_config():
+    opt = AdaBeliefOptimizer(lr=1e-4)
+    config = opt.get_config()
+    assert config["learning_rate"] == 1e-4
+    assert config["total_steps"] == 0
+
+
+def test_serialization():
+    optimizer = AdaBeliefOptimizer(
+        lr=1e-3, total_steps=10000, warmup_proportion=0.1, min_lr=1e-5
+    )
+    config = tf.keras.optimizers.serialize(optimizer)
+    new_optimizer = tf.keras.optimizers.deserialize(config, custom_objects={"AdaBeliefOptimizer": AdaBeliefOptimizer})
+    assert new_optimizer.get_config() == optimizer.get_config()
+
+
+@pytest.mark.usefixtures("maybe_run_functions_eagerly")
+def test_schedulers():
+    lr_scheduler = tf.keras.optimizers.schedules.ExponentialDecay(1e-3, 50, 0.5)
+    wd_scheduler = tf.keras.optimizers.schedules.InverseTimeDecay(2e-3, 25, 0.25)
+
+    run_dense_sample(
+        iterations=100,
+        expected=[[0.9778532, 1.9773799], [2.977964, 3.977844]],
+        optimizer=AdaBeliefOptimizer(learning_rate=lr_scheduler, weight_decay=wd_scheduler),
+    )
+
+
+def test_scheduler_serialization():
+    lr_scheduler = tf.keras.optimizers.schedules.ExponentialDecay(1e-3, 50, 0.5)
+    wd_scheduler = tf.keras.optimizers.schedules.InverseTimeDecay(2e-3, 25, 0.25)
+
+    optimizer = AdaBeliefOptimizer(learning_rate=lr_scheduler, weight_decay=wd_scheduler)
+    config = tf.keras.optimizers.serialize(optimizer)
+    new_optimizer = tf.keras.optimizers.deserialize(config, custom_objects={"AdaBeliefOptimizer": AdaBeliefOptimizer})
+    assert new_optimizer.get_config() == optimizer.get_config()
+
+    assert new_optimizer.get_config()["learning_rate"] == {
+        "class_name": "ExponentialDecay",
+        "config": lr_scheduler.get_config(),
+    }
+
+    assert new_optimizer.get_config()["weight_decay"] == {
+        "class_name": "InverseTimeDecay",
+        "config": wd_scheduler.get_config(),
+    }
+
+
+if __name__ == "__main__":
+    dirname = Path(__file__).absolute().parent
+    sys.exit(pytest.main([str(dirname)]))

--- a/pypi_packages/adabelief_tf0.3.0/adabelief_tf2/LICENSE.txt
+++ b/pypi_packages/adabelief_tf0.3.0/adabelief_tf2/LICENSE.txt
@@ -1,0 +1,19 @@
+Copyright (c) 2018 The Python Packaging Authority
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pypi_packages/adabelief_tf0.3.0/adabelief_tf2/README.md
+++ b/pypi_packages/adabelief_tf0.3.0/adabelief_tf2/README.md
@@ -1,0 +1,1 @@
+Tensorflow implementation of Adabelief Optimizer. For details, please see https://juntang-zhuang.github.io/adabelief/

--- a/pypi_packages/adabelief_tf0.3.0/adabelief_tf2/adabelief_tf/AdaBelief_tf.py
+++ b/pypi_packages/adabelief_tf0.3.0/adabelief_tf2/adabelief_tf/AdaBelief_tf.py
@@ -1,0 +1,344 @@
+""" AdaBelief for TensorFlow 2.x."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import tensorflow as tf
+
+from tabulate import tabulate
+from colorama import Fore, Back, Style
+
+
+class AdaBeliefOptimizer(tf.keras.optimizers.Optimizer):
+    """
+    It implements the AdaBeliefOptimizer proposed by
+    Juntang Zhuang et al. in [AdaBelief Optimizer: Adapting stepsizes by the belief
+    in observed gradients](https://arxiv.org/abs/2010.07468).
+    Contributor(s):
+        Jerry Yu [cryu854] <cryu854@gmail.com>
+    
+    Inherits from: tf.keras.optimizers.Optimizer.
+    Example of usage:
+    ```python
+    from adabelief_tf import AdaBeliefOptimizer
+    opt = AdaBeliefOptimizer(lr=1e-3)
+    ```
+    Note: `amsgrad` is not described in the original paper. Use it with
+          caution.
+    AdaBeliefOptimizer is not a placement of the heuristic warmup, the settings should be
+    kept if warmup has already been employed and tuned in the baseline method.
+    You can enable warmup by setting `total_steps` and `warmup_proportion`:
+    ```python
+    opt = AdaBeliefOptimizer(
+        lr=1e-3,
+        total_steps=10000,
+        warmup_proportion=0.1,
+        min_lr=1e-5,
+    )
+    ```
+    In the above example, the learning rate will increase linearly
+    from 0 to `lr` in 1000 steps, then decrease linearly from `lr` to `min_lr`
+    in 9000 steps.
+    Lookahead, proposed by Michael R. Zhang et.al in the paper
+    [Lookahead Optimizer: k steps forward, 1 step back]
+    (https://arxiv.org/abs/1907.08610v1), can be integrated with AdaBeliefOptimizer,
+    which is announced by Less Wright and the new combined optimizer can also
+    be called "Ranger". The mechanism can be enabled by using the lookahead
+    wrapper. For example:
+    ```python
+    adabelief = AdaBeliefOptimizer()
+    ranger = tfa.optimizers.Lookahead(adabelief, sync_period=6, slow_step_size=0.5)
+    ```
+    Example of serialization:
+    ```python
+    optimizer = AdaBeliefOptimizer(learning_rate=lr_scheduler, weight_decay=wd_scheduler)
+    config = tf.keras.optimizers.serialize(optimizer)
+    new_optimizer = tf.keras.optimizers.deserialize(config, custom_objects={"AdaBeliefOptimizer": AdaBeliefOptimizer})
+    ```
+    """
+
+    def __init__(
+        self,
+        learning_rate=0.001,
+        beta_1=0.9,
+        beta_2=0.999,
+        epsilon=1e-14,
+        weight_decay=0.0,
+        rectify=True,
+        amsgrad=False,
+        sma_threshold=5.0,
+        total_steps=0,
+        warmup_proportion=0.1,
+        min_lr=0.0,
+        name="AdaBeliefOptimizer",
+        print_change_log = True,
+        **kwargs):
+        r"""Construct a new AdaBelief optimizer.
+        Args:
+            learning_rate: A `Tensor` or a floating point value, or a schedule
+                that is a `tf.keras.optimizers.schedules.LearningRateSchedule`.
+                The learning rate.
+            beta_1: A float value or a constant float tensor.
+                The exponential decay rate for the 1st moment estimates.
+            beta_2: A float value or a constant float tensor.
+                The exponential decay rate for the 2nd moment estimates.
+            epsilon: A small constant for numerical stability.
+            weight_decay: A `Tensor` or a floating point value, or a schedule
+                that is a `tf.keras.optimizers.schedules.LearningRateSchedule`.
+                Weight decay for each parameter.
+            rectify: boolean. Whether to enable rectification as in RectifiedAdam
+            amsgrad: boolean. Whether to apply AMSGrad variant of this
+                algorithm from the paper "On the Convergence of Adam and
+                beyond".
+            sma_threshold. A float value.
+                The threshold for simple mean average.
+            total_steps: An integer. Total number of training steps.
+                Enable warmup by setting a positive value.
+            warmup_proportion: A floating point value.
+                The proportion of increasing steps.
+            min_lr: A floating point value. Minimum learning rate after warmup.
+            name: Optional name for the operations created when applying
+                gradients. Defaults to "AdaBeliefOptimizer".
+            **kwargs: keyword arguments. Allowed to be {`clipnorm`,
+                `clipvalue`, `lr`, `decay`}. `clipnorm` is clip gradients
+                by norm; `clipvalue` is clip gradients by value, `decay` is
+                included for backward compatibility to allow time inverse
+                decay of learning rate. `lr` is included for backward
+                compatibility, recommended to use `learning_rate` instead.
+        """
+        super().__init__(name, **kwargs)
+
+        # ------------------------------------------------------------------------------
+        # Print modifications to default arguments
+        if print_change_log:
+            print(Fore.RED + 'Please check your arguments if you have upgraded adabelief-tf from version 0.0.1.')
+            print(Fore.RED + 'Modifications to default arguments:')
+            default_table = tabulate([
+                ['adabelief-tf=0.0.1','1e-8','Not supported','Not supported'],
+                ['>=0.1.0 (Current 0.2.1)','1e-14','supported','default: True']],
+                headers=['eps','weight_decouple','rectify'])
+            print(Fore.RED + default_table)
+
+            recommend_table = tabulate([
+                ['Recommended epsilon = 1e-7', 'Recommended epsilon = 1e-14'],
+                ],
+                headers=['SGD better than Adam (e.g. CNN for Image Classification)','Adam better than SGD (e.g. Transformer, GAN)'])
+            print(Fore.BLUE + recommend_table)
+
+            print(Fore.BLUE +'For a complete table of recommended hyperparameters, see')
+            print(Fore.BLUE + 'https://github.com/juntang-zhuang/Adabelief-Optimizer')
+
+            print(Fore.GREEN + 'You can disable the log message by setting "print_change_log = False", though it is recommended to keep as a reminder.')
+
+            print(Style.RESET_ALL)
+        # ------------------------------------------------------------------------------
+
+        self._set_hyper("learning_rate", kwargs.get("lr", learning_rate))
+        self._set_hyper("beta_1", beta_1)
+        self._set_hyper("beta_2", beta_2)
+        self._set_hyper("decay", self._initial_decay)
+        self._set_hyper("weight_decay", weight_decay)
+        self._set_hyper("sma_threshold", sma_threshold)
+        self._set_hyper("total_steps", int(total_steps))
+        self._set_hyper("warmup_proportion", warmup_proportion)
+        self._set_hyper("min_lr", min_lr)
+        self.epsilon = epsilon or tf.keras.backend.epsilon()
+        self.amsgrad = amsgrad
+        self.rectify = rectify
+        self._has_weight_decay = weight_decay != 0.0
+        self._initial_total_steps = total_steps
+
+    def _create_slots(self, var_list):
+        for var in var_list:
+            self.add_slot(var, "m")
+            self.add_slot(var, "v")
+            if self.amsgrad:
+                self.add_slot(var, "vhat")
+
+    def set_weights(self, weights):
+        params = self.weights
+        num_vars = int((len(params) - 1) / 2)
+        if len(weights) == 3 * num_vars + 1:
+            weights = weights[: len(params)]
+        super().set_weights(weights)
+
+    def _decayed_wd(self, var_dtype):
+        wd_t = self._get_hyper("weight_decay", var_dtype)
+        if isinstance(wd_t, tf.keras.optimizers.schedules.LearningRateSchedule):
+            wd_t = tf.cast(wd_t(self.iterations), var_dtype)
+        return wd_t
+
+    def _resource_apply_dense(self, grad, var):
+        var_dtype = var.dtype.base_dtype
+        lr_t = self._decayed_lr(var_dtype)
+        wd_t = self._decayed_wd(var_dtype)
+        m = self.get_slot(var, "m")
+        v = self.get_slot(var, "v")
+        beta_1_t = self._get_hyper("beta_1", var_dtype)
+        beta_2_t = self._get_hyper("beta_2", var_dtype)
+        epsilon_t = tf.convert_to_tensor(self.epsilon, var_dtype)
+        local_step = tf.cast(self.iterations + 1, var_dtype)
+        beta_1_power = tf.math.pow(beta_1_t, local_step)
+        beta_2_power = tf.math.pow(beta_2_t, local_step)
+
+        if self._initial_total_steps > 0:
+            total_steps = self._get_hyper("total_steps", var_dtype)
+            warmup_steps = total_steps * self._get_hyper("warmup_proportion", var_dtype)
+            min_lr = self._get_hyper("min_lr", var_dtype)
+            decay_steps = tf.maximum(total_steps - warmup_steps, 1)
+            decay_rate = (min_lr - lr_t) / decay_steps
+            lr_t = tf.where(
+                local_step <= warmup_steps,
+                lr_t * (local_step / warmup_steps),
+                lr_t + decay_rate * tf.minimum(local_step - warmup_steps, decay_steps),
+            )
+
+
+
+        m_t = m.assign(
+            beta_1_t * m + (1.0 - beta_1_t) * grad, use_locking=self._use_locking
+        )
+        m_corr_t = m_t / (1.0 - beta_1_power)
+
+        v_t = v.assign(
+            beta_2_t * v + (1.0 - beta_2_t) * tf.math.square(grad - m_t) + epsilon_t,
+            use_locking=self._use_locking,
+        )
+
+        if self.amsgrad:
+            vhat = self.get_slot(var, "vhat")
+            vhat_t = vhat.assign(tf.maximum(vhat, v_t), use_locking=self._use_locking)
+            v_corr_t = tf.math.sqrt(vhat_t / (1.0 - beta_2_power))
+        else:
+            vhat_t = None
+            v_corr_t = tf.math.sqrt(v_t / (1.0 - beta_2_power))
+
+
+
+        if self.rectify:
+            sma_inf = 2.0 / (1.0 - beta_2_t) - 1.0
+            sma_t = sma_inf - 2.0 * local_step * beta_2_power / (1.0 - beta_2_power)
+            r_t = tf.math.sqrt(
+                (sma_t - 4.0)
+                / (sma_inf - 4.0)
+                * (sma_t - 2.0)
+                / (sma_inf - 2.0)
+                * sma_inf
+                / sma_t
+            )
+            sma_threshold = self._get_hyper("sma_threshold", var_dtype)
+            var_t = tf.where(
+                sma_t >= sma_threshold,
+                r_t * m_corr_t / (v_corr_t + epsilon_t),
+                m_corr_t,
+            )
+        else:
+            var_t = m_corr_t / (v_corr_t + epsilon_t)
+
+        if self._has_weight_decay:
+            var_t += wd_t * var
+
+        var_update = var.assign_sub(lr_t * var_t, use_locking=self._use_locking)
+
+        updates = [var_update, m_t, v_t]
+        if self.amsgrad:
+            updates.append(vhat_t)
+        return tf.group(*updates)
+
+    def _resource_apply_sparse(self, grad, var, indices):
+        var_dtype = var.dtype.base_dtype
+        lr_t = self._decayed_lr(var_dtype)
+        wd_t = self._decayed_wd(var_dtype)
+        beta_1_t = self._get_hyper("beta_1", var_dtype)
+        beta_2_t = self._get_hyper("beta_2", var_dtype)
+        epsilon_t = tf.convert_to_tensor(self.epsilon, var_dtype)
+        local_step = tf.cast(self.iterations + 1, var_dtype)
+        beta_1_power = tf.math.pow(beta_1_t, local_step)
+        beta_2_power = tf.math.pow(beta_2_t, local_step)
+
+        if self._initial_total_steps > 0:
+            total_steps = self._get_hyper("total_steps", var_dtype)
+            warmup_steps = total_steps * self._get_hyper("warmup_proportion", var_dtype)
+            min_lr = self._get_hyper("min_lr", var_dtype)
+            decay_steps = tf.maximum(total_steps - warmup_steps, 1)
+            decay_rate = (min_lr - lr_t) / decay_steps
+            lr_t = tf.where(
+                local_step <= warmup_steps,
+                lr_t * (local_step / warmup_steps),
+                lr_t + decay_rate * tf.minimum(local_step - warmup_steps, decay_steps),
+            )
+
+        m = self.get_slot(var, "m")
+        m_scaled_g_values = grad * (1 - beta_1_t)
+        m_t = m.assign(m * beta_1_t, use_locking=self._use_locking)
+        m_t = self._resource_scatter_add(m, indices, m_scaled_g_values)
+        m_corr_t = m_t / (1.0 - beta_1_power)
+
+        v = self.get_slot(var, "v")
+        m_t_indices = tf.gather(m_t, indices)
+        v_scaled_g_values = tf.math.square(grad - m_t_indices) * (1 - beta_2_t)
+        v_t = v.assign(v * beta_2_t + epsilon_t, use_locking=self._use_locking)
+        v_t = self._resource_scatter_add(v, indices, v_scaled_g_values)
+
+        if self.amsgrad:
+            vhat = self.get_slot(var, "vhat")
+            vhat_t = vhat.assign(tf.maximum(vhat, v_t), use_locking=self._use_locking)
+            v_corr_t = tf.math.sqrt(vhat_t / (1.0 - beta_2_power))
+        else:
+            vhat_t = None
+            v_corr_t = tf.math.sqrt(v_t / (1.0 - beta_2_power))
+
+        if self.rectify:
+            sma_inf = 2.0 / (1.0 - beta_2_t) - 1.0
+            sma_t = sma_inf - 2.0 * local_step * beta_2_power / (1.0 - beta_2_power)
+            r_t = tf.math.sqrt(
+                (sma_t - 4.0)
+                / (sma_inf - 4.0)
+                * (sma_t - 2.0)
+                / (sma_inf - 2.0)
+                * sma_inf
+                / sma_t
+            )
+            sma_threshold = self._get_hyper("sma_threshold", var_dtype)
+            var_t = tf.where(
+                sma_t >= sma_threshold,
+                r_t * m_corr_t / (v_corr_t + epsilon_t),
+                m_corr_t,
+            )
+        else:
+            var_t = m_corr_t / (v_corr_t + epsilon_t)
+
+        if self._has_weight_decay:
+            var_t += wd_t * var
+
+        var_update = self._resource_scatter_add(
+            var, indices, tf.gather(tf.math.negative(lr_t) * var_t, indices)
+        )
+
+        updates = [var_update, m_t, v_t]
+        if self.amsgrad:
+            updates.append(vhat_t)
+        return tf.group(*updates)
+
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "learning_rate": self._serialize_hyperparameter("learning_rate"),
+                "beta_1": self._serialize_hyperparameter("beta_1"),
+                "beta_2": self._serialize_hyperparameter("beta_2"),
+                "decay": self._serialize_hyperparameter("decay"),
+                "weight_decay": self._serialize_hyperparameter("weight_decay"),
+                "sma_threshold": self._serialize_hyperparameter("sma_threshold"),
+                "epsilon": self.epsilon,
+                "amsgrad": self.amsgrad,
+                "rectify": self.rectify,
+                "total_steps": self._serialize_hyperparameter("total_steps"),
+                "warmup_proportion": self._serialize_hyperparameter(
+                    "warmup_proportion"
+                ),
+                "min_lr": self._serialize_hyperparameter("min_lr"),
+            }
+        )
+        return config

--- a/pypi_packages/adabelief_tf0.3.0/adabelief_tf2/adabelief_tf/__init__.py
+++ b/pypi_packages/adabelief_tf0.3.0/adabelief_tf2/adabelief_tf/__init__.py
@@ -1,0 +1,2 @@
+from .AdaBelief_tf import AdaBeliefOptimizer
+__version__='0.3.0'

--- a/pypi_packages/adabelief_tf0.3.0/adabelief_tf2/setup.py
+++ b/pypi_packages/adabelief_tf0.3.0/adabelief_tf2/setup.py
@@ -1,0 +1,27 @@
+import setuptools
+
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
+setuptools.setup(
+    name="adabelief_tf", 
+    version="0.3.0",
+    author="Juntang Zhuang",
+    author_email="j.zhuang@yale.edu",
+    description="Tensorflow implementation of AdaBelief Optimizer",
+    long_description="Tensorflow implementation of AdaBelief Optimizer",
+    long_description_content_type="text/markdown",
+    url="https://juntang-zhuang.github.io/adabelief/",
+    packages=setuptools.find_packages(),
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+    ],
+    install_requires=[
+          'tensorflow>=2.0.0',
+          'colorama>=0.4.0',
+          'tabulate>=0.7',
+      ],
+    python_requires='>=3.6',
+)


### PR DESCRIPTION
Update notes:
- Implement an adabelief in tf1.x version. 
  - The optimizer inherits from `tf.train.Optimizer` and supports same features as adabelief in tf2.
- Add test code for adabelief in tf1 and tf2. 
  - The code was developed from tensorflow's [adam_test.py](https://github.com/tensorflow/tensorflow/blob/v1.15.0/tensorflow/python/training/adam_test.py).
- Optimize rectify. 
  - For adabelief in tf2, some calculations are not being used when `rectify = False`.

I also tried several examples from https://github.com/aymericdamien/TensorFlow-Examples/tree/master/tensorflow_v1/notebooks for tf1.x version. 